### PR TITLE
add iridium cleaner

### DIFF
--- a/pending/iridium.xml
+++ b/pending/iridium.xml
@@ -1,0 +1,178 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    BleachBit
+    Copyright (C) 2008-2019 Andrew Ziem
+    https://www.bleachbit.org
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+<cleaner id="iridium">
+  <label>Iridium</label>
+  <description>Web browser</description>
+  <running type="exe" os="windows">iridium.exe</running>
+  <running type="exe" os="linux">iridium-browser</running>
+  <!-- OpenBSD and NetBSD use "chrome" for iridium, while on Linux it means
+    Google Chrome. In other words, on Linux this could give a false positive
+    for iridium when Google Chrome is running. -->
+  <running type="exe" os="bsd">chrome</running>
+  <var name="base">
+    <value os="windows">%LocalAppData%\Iridium\User Data</value>
+    <value os="linux">$XDG_CONFIG_HOME/iridium</value>
+    <value os="freebsd">$XDG_CONFIG_HOME/iridium</value>
+    <value os="openbsd">$XDG_CONFIG_HOME/iridium</value>
+  </var>
+  <var name="profile">
+    <value os="windows">%LocalAppData%\Iridium\User Data\Default</value>
+    <value os="linux">$XDG_CONFIG_HOME/iridium/Default</value>
+    <value os="freebsd">$XDG_CONFIG_HOME/iridium/Default</value>
+    <value os="openbsd">$XDG_CONFIG_HOME/iridium/Default</value>
+  </var>
+  <option id="cache">
+    <label>Cache</label>
+    <description>Delete the web cache, which reduces time to display revisited pages</description>
+    <action command="delete" search="file" path="$$base$$/Safe Browsing Channel IDs-journal"/>
+    <action command="delete" search="file" path="$$profile$$/Network Persistent State"/>
+    <action command="delete" search="walk.all" path="$$base$$/ShaderCache"/>
+    <action command="delete" search="walk.all" path="$$profile$$/File System"/>
+    <action command="delete" search="walk.all" path="$$profile$$/Service Worker"/>
+    <action command="delete" search="walk.all" path="$$profile$$/Storage/ext/*/*def/GPUCache"/>
+    <action command="delete" search="walk.files" path="$$profile$$/GPUCache/"/>
+    <action command="json" search="file" path="$$profile$$/Preferences" address="dns_prefetching/host_referral_list"/>
+    <action command="json" search="file" path="$$profile$$/Preferences" address="dns_prefetching/startup_list"/>
+    <action command="json" search="file" path="$$profile$$/Preferences" address="net/http_server_properties/servers"/>
+    <action command="json" search="file" path="$$base$$/Local State" address="HostReferralList"/>
+    <action command="json" search="file" path="$$base$$/Local State" address="StartupDNSPrefetchList"/>
+    <!-- Linux-specific -->
+    <action command="delete" search="walk.files" path="$XDG_CACHE_HOME/iridium/"/>
+    <!-- Windows-specific -->
+    <action command="delete" search="glob" path="$$base$$\B*.tmp"/>
+    <action command="delete" search="walk.all" path="$$profile$$\Default\Application Cache\"/>
+    <action command="delete" search="walk.files" path="$$profile$$\Cache\"/>
+    <action command="delete" search="walk.files" path="$$profile$$\Media Cache\"/>
+  </option>
+  <option id="cookies">
+    <label>Cookies</label>
+    <description>Delete cookies, which contain information such as web site preferences, authentication, and tracking identification</description>
+    <action command="delete" search="file" path="$$profile$$/Cookies"/>
+    <action command="delete" search="file" path="$$profile$$/Cookies-journal"/>
+    <action command="delete" search="file" path="$$profile$$/Extension Cookies"/>
+    <action command="delete" search="file" path="$$profile$$/Extension Cookies-journal"/>
+  </option>
+  <option id="dom">
+    <label>DOM Storage</label>
+    <description>Delete HTML5 cookies</description>
+    <!-- do not delete extension preferences ~/.config/iridium/Default/database/chrome-extension* (Fedora 14, Iridium 12) -->
+    <action command="chrome.databases_db" search="file" path="$$profile$$/databases/Databases.db"/>
+    <action command="delete" search="glob" path="$$profile$$/Local Storage/http*localstorage"/>
+    <action command="delete" search="glob" path="$$profile$$/Local Storage/http*localstorage-journal"/>
+    <action command="delete" search="walk.all" path="$$profile$$/databases/http*/"/>
+    <action command="delete" search="walk.all" path="$$profile$$/Local Storage/leveldb"/>
+  </option>
+  <option id="form_history">
+    <label>Form history</label>
+    <description>A history of forms entered in web sites</description>
+    <action command="chrome.autofill" search="file" path="$$profile$$/Web Data"/>
+  </option>
+  <option id="history">
+    <label>History</label>
+    <description>Delete the history which includes visited sites, downloads, and thumbnails</description>
+    <!-- keep /History before /Favicons -->
+    <action command="chrome.history" search="file" path="$$profile$$/History"/>
+    <action command="chrome.favicons" search="file" path="$$profile$$/Favicons"/>
+    <action command="delete" search="file" path="$$base$$/chrome_shutdown_ms.txt"/>
+    <action command="delete" search="file" path="$$base$$/Safe Browsing Cookies-journal"/>
+    <action command="delete" search="file" path="$$profile$$/Archived History"/>
+    <action command="delete" search="file" path="$$profile$$/Archived History-journal"/>
+    <action command="delete" search="file" path="$$profile$$/DownloadMetadata"/>
+    <action command="delete" search="file" path="$$profile$$/History-journal"/>
+    <action command="delete" search="glob" path="$$profile$$/History Index ????-??"/>
+    <action command="delete" search="glob" path="$$profile$$/History Index ????-??-journal"/>
+    <action command="delete" search="file" path="$$profile$$/History Provider Cache"/>
+    <action command="delete" search="file" path="$$profile$$/Network Action Predictor"/>
+    <action command="delete" search="file" path="$$profile$$/Network Action Predictor-journal"/>
+    <action command="delete" search="file" path="$$profile$$/Origin Bound Certs-journal"/>
+    <action command="delete" search="file" path="$$profile$$/Shortcuts"/>
+    <action command="delete" search="file" path="$$profile$$/Shortcuts-journal"/>
+    <!-- Before about January 2016 Thumbnails was an SQLite file, by Google Chrome 48 it is a folder -->
+    <action command="delete" search="file" path="$$profile$$/Thumbnails"/>
+    <action command="delete" search="walk.files" path="$$profile$$/Thumbnails"/>
+    <action command="delete" search="file" path="$$profile$$/Thumbnails-journal"/>
+    <action command="delete" search="file" path="$$profile$$/Top Sites"/>
+    <action command="delete" search="file" path="$$profile$$/Top Sites-journal"/>
+    <action command="delete" search="file" path="$$profile$$/Visited Links"/>
+    <action command="delete" search="file" path="$$profile$$/QuotaManager"/>
+    <action command="delete" search="file" path="$$profile$$/QuotaManager-journal"/>
+    <action command="delete" search="walk.files" path="$$profile$$/Session Storage/"/>
+    <action command="json" search="file" path="$$profile$$/Preferences" address="profile/content_settings/exceptions"/>
+    <!-- Windows-specific -->
+    <action command="delete" search="walk.files" path="$$profile$$\JumpListIconsMostVisited\"/>
+    <action command="delete" search="walk.files" path="$$profile$$\JumpListIconsOld\"/>
+    <action command="delete" search="walk.files" path="$$profile$$\JumpListIconsRecentClosed\"/>
+    <action command="delete" search="walk.files" path="$$profile$$\JumpListIcons\"/>
+  </option>
+  <option id="search_engines">
+    <label>Search engines</label>
+    <description translators="'Factory' means a search engine that is installed by default 'from the factory,' but this is different than a 'default search engine' https://lists.launchpad.net/launchpad-translators/msg00283.html">Reset the search engine usage history and delete non-factory search engines, some of which are added automatically</description>
+    <action command="chrome.keywords" search="file" path="$$profile$$/Web Data"/>
+  </option>
+  <option id="session">
+    <label>Session</label>
+    <description>Delete the current and last sessions</description>
+    <action command="delete" search="file" path="$$profile$$/Current Session"/>
+    <action command="delete" search="file" path="$$profile$$/Current Tabs"/>
+    <action command="delete" search="file" path="$$profile$$/Last Session"/>
+    <action command="delete" search="file" path="$$profile$$/Last Tabs"/>
+    <action command="delete" search="walk.all" path="$$profile$$/Extension State"/>
+  </option>
+  <option id="sync">
+    <label>Sync</label>
+    <description>Delete the sync data and sign out of the browser</description>
+    <action command="delete" search="walk.files" path="$$profile$$/Sync Data/"/>
+    <!-- Sync Data Backup not seen in Iridium 65 -->
+    <action command="json" search="file" path="$$base$$/Local State" address="profile"/>
+    <action command="json" search="file" path="$$profile$$/Preferences" address="account_info"/>
+    <action command="json" search="file" path="$$profile$$/Preferences" address="google_services"/>
+    <action command="json" search="file" path="$$profile$$/Preferences" address="sync"/>
+  </option>
+  <option id="passwords">
+    <label>Passwords</label>
+    <description>A database of usernames and passwords as well as a list of sites that should not store passwords</description>
+    <warning>This option will delete your saved passwords.</warning>
+    <action command="delete" search="file" path="$$profile$$/Login Data"/>
+    <action command="delete" search="file" path="$$profile$$/Login Data-journal"/>
+  </option>
+  <option id="vacuum">
+    <label>Vacuum</label>
+    <description>Clean database fragmentation to reduce space and improve speed without removing any data</description>
+    <action command="sqlite.vacuum" search="file" path="$$profile$$/Cookies"/>
+    <action command="sqlite.vacuum" search="file" path="$$profile$$/Extension Cookies"/>
+    <action command="sqlite.vacuum" search="file" path="$$profile$$/History"/>
+    <action command="sqlite.vacuum" search="glob" path="$$profile$$/History Index ????-??"/>
+    <action command="sqlite.vacuum" search="file" path="$$profile$$/Login Data"/>
+    <action command="sqlite.vacuum" search="file" path="$$profile$$/Origin Bound Certs"/>
+    <action command="sqlite.vacuum" search="file" path="$$profile$$/Network Action Predictor"/>
+    <action command="sqlite.vacuum" search="file" path="$$profile$$/previews_opt_out.db"/>
+    <action command="sqlite.vacuum" search="file" path="$$profile$$/QuotaManager"/>
+    <action command="sqlite.vacuum" search="file" path="$$profile$$/Shortcuts"/>
+    <!-- Before about January 2016 Thumbnails was an SQLite file, by Google Chrome 48 it is a folder -->
+    <action command="sqlite.vacuum" search="file" path="$$profile$$/Thumbnails" type="f"/>
+    <action command="sqlite.vacuum" search="file" path="$$profile$$/Top Sites"/>
+    <action command="sqlite.vacuum" search="file" path="$$profile$$/Web Data"/>
+    <action command="sqlite.vacuum" search="file" path="$$profile$$/databases/Databases.db"/>
+    <action command="sqlite.vacuum" search="glob" path="$$profile$$/databases/http*/?"/>
+    <action command="sqlite.vacuum" search="glob" path="$$profile$$/databases/http*/??"/>
+    <action command="sqlite.vacuum" search="file" path="$$profile$$/Sync Data/SyncData.sqlite3"/>
+    <!-- The three below were seen on Google Chrome on Windows before Chrome version 66 -->
+    <action command="sqlite.vacuum" search="file" path="%LocalAppData%\Google\Chrome\User Data\Default\Archived History"/>
+    <action command="sqlite.vacuum" search="file" path="%LocalAppData%\Google\Chrome\User Data\Default\Plugin Data\Google Gears\localserver.db"/>
+    <action command="sqlite.vacuum" search="file" path="%LocalAppData%\Google\Chrome\User Data\Default\Plugin Data\Google Gears\permissions.db"/>
+  </option>
+</cleaner>


### PR DESCRIPTION
This is the chromium cleaner edited and tested for iridium-browser, a privacy focussed chromium variant.

Tested on Ubuntu 18.04 LTS, all options: iridium.cache iridium.cookies iridium.dom iridium.form_history iridium.history iridium.search_engines iridium.session iridium.sync iridium.passwords iridium.vacuum

I failed to capture the terminal output.
(No errors on 18.04 LTS, not tested on Windows)

Iridium Browser is based on the Chromium code base. All modifications enhance the privacy of the user and make sure that the latest and best secure technologies are used.Automatic transmission of partial queries, keywords and metrics to central services is prevented and only occurs with the approval of the user.
https://iridiumbrowser.de/