### PR TITLE
new cleaner : pix ( history )

### DIFF
--- a/pending/pix.xml
+++ b/pending/pix.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+(c) Pascal Klein
+21/FEB/2021
+
+BleachBit CleanerML cleaner for:
+Pix (based on gThumb) photo browser
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+-->
+<cleaner id="pix" os="linux">
+  <label>Pix</label>
+  <description>Photo browser</description>
+  <running type="exe" os="linux">pix</running>
+
+  <option id="history">
+    <label>History</label>
+    <description>Delete the history</description>
+    <action command="delete" search="file" path="~/.config/pix/history.xbel"/>
+  </option>
+</cleaner>


### PR DESCRIPTION
deletes history of pix image browser

(referring from https://github.com/bleachbit/bleachbit/pull/1128 )