### PR TITLE
adding temp option for chocolatey cleaner

### DIFF
--- a/pending/chocolatey.xml
+++ b/pending/chocolatey.xml
@@ -31,4 +31,9 @@
     <description>Delete the cache</description>
     <action command="delete" search="walk.all" path="$LOCALAPPDATA\NuGet\Cache"/>
   </option>
+  <option id="temp">
+    <label>Temp</label>
+    <description>Delete the temporary files</description>
+    <action command="delete" search="walk.files" path="$localappdata\temp\chocolatey\" nregex="\.log$" />
+  </option>
 </cleaner>


### PR DESCRIPTION
Clean the temp folder for Chocolatey, however it leaves the log files alone.